### PR TITLE
ci(Github Action): update Node.js version in `lint` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 21
+          node-version: 22
       - name: Install dependencies
         run: pnpm i
       - name: Check eslint


### PR DESCRIPTION
- Changed `node-version` from `21` to `22` in `.github/workflows/lint.yml`
- This update ensures compatibility with the latest Node.js features and improvements in the linting process.