### PR TITLE
build(npm): remove unused devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,9 @@
     "format": "prettier --write .",
     "format:check": "prettier -c .",
     "lint": "eslint --fix .",
-    "lint:check": "eslint .",
-    "test": "jest --slient=false --verbose=true"
+    "lint:check": "eslint ."
   },
   "devDependencies": {
-    "@jest/globals": "^29.6.2",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
@@ -47,10 +45,8 @@
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-scope": "^8.0.0",
     "eslint-visitor-keys": "^4.0.0",
-    "jest": "^29.6.2",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
-    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typedoc": "^0.26.3",
     "typescript": "^5.1.6"


### PR DESCRIPTION
- Removed `@jest/globals` and `jest` from `devDependencies` as they are no longer needed
- Simplified `scripts` section by removing the `test` script, which was previously configured for Jest