### PR TITLE
chore(eslint): remove overrides for jest config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,13 +4,6 @@ env:
 extends:
   - standard-with-typescript
   - prettier
-overrides:
-  - env:
-      node: true
-    files:
-      - jest.config.ts
-    parserOptions:
-      sourceType: script
 parserOptions:
   ecmaVersion: latest
   project:


### PR DESCRIPTION
- Deleted the `overrides` section for `jest.config.ts` in `.eslintrc.yml`
- This change simplifies the ESLint configuration by removing unnecessary overrides for the Node environment