### PR TITLE
build(npm): update lint:check command to include TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format": "prettier --write .",
     "format:check": "prettier -c .",
     "lint": "eslint --fix . --ext .ts --ignore-path .gitignore",
-    "lint:check": "eslint ."
+    "lint:check": "eslint . --ext .ts --ignore-path .gitignore"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",


### PR DESCRIPTION
- Modify the `lint:check` script in `package.json` to include the `--ext .ts` flag.
- This ensures that TypeScript files are properly linted along with JavaScript files.
- Improves code quality checks and aligns with existing linting practices.