### PR TITLE
build(npm): remove `eslint-config-standard` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-config-standard": "^17.1.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
     "eslint-import-resolver-node": "^0.3.7",
     "eslint-module-utils": "^2.8.0",


### PR DESCRIPTION
- Deleted `eslint-config-standard` version `17.1.0` from `package.json`
- This change reduces the package size and eliminates potential conflicts with other ESLint configurations
- Maintained `eslint-config-standard-with-typescript` to ensure TypeScript compatibility