### PR TITLE
build(npm): remove outdated `eslint-import-resolver-node` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
-    "eslint-import-resolver-node": "^0.3.7",
     "eslint-module-utils": "^2.8.0",
     "eslint-plugin-es-x": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",


### PR DESCRIPTION
- Removed the `eslint-import-resolver-node` dependency, which was outdated and not required anymore
- This cleanup helps streamline the project's dependencies and maintain compatibility with the latest ESLint configurations