### PR TITLE
build(npm): remove outdated ESLint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
-    "eslint-module-utils": "^2.8.0",
     "eslint-plugin-es-x": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.1",


### PR DESCRIPTION
- removed `eslint-module-utils` version `^2.8.0` from `package.json`
- this change streamlines dependencies and ensures compatibility with current ESLint configurations