### PR TITLE
build(npm): update lint scripts for TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "doc": "typedoc",
     "format": "prettier --write .",
     "format:check": "prettier -c .",
-    "lint": "eslint --fix .",
-    "lint:check": "eslint ."
+    "lint": "eslint --fix . --ext .ts --ignore-path .gitignore",
+    "lint:check": "eslint . --ext .ts --ignore-path .gitignore"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",


### PR DESCRIPTION
- Modify `lint` and `lint:check` scripts to include TypeScript file extensions
- Add `--ignore-path .gitignore` to ignore files listed in `.gitignore` during linting
- Enhance code quality checks for a more streamlined development process