### PR TITLE
build(npm): remove `eslint-config-standard` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-config-standard": "^17.1.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
     "eslint-import-resolver-node": "^0.3.7",
     "eslint-module-utils": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       eslint-config-prettier:
         specifier: ^9.0.0
         version: 9.1.0(eslint@8.57.1)
-      eslint-config-standard:
-        specifier: ^17.1.0
-        version: 17.1.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-with-typescript:
         specifier: ^36.1.0
         version: 36.1.1(@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)(typescript@5.6.3)


### PR DESCRIPTION
- Removed `eslint-config-standard` from `package.json` and `pnpm-lock.yaml`
- This change helps streamline ESLint configuration and reduces potential conflicts with other configurations