### PR TITLE
build(npm): remove `eslint-import-resolver-node` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
-    "eslint-import-resolver-node": "^0.3.7",
     "eslint-module-utils": "^2.8.0",
     "eslint-plugin-es-x": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       eslint-config-standard-with-typescript:
         specifier: ^36.1.0
         version: 36.1.1(@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)(typescript@5.6.3)
-      eslint-import-resolver-node:
-        specifier: ^0.3.7
-        version: 0.3.9
       eslint-module-utils:
         specifier: ^2.8.0
         version: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)


### PR DESCRIPTION
- Removed `eslint-import-resolver-node` version `0.3.7` from `package.json`
- Updated `pnpm-lock.yaml` to reflect the removal of the dependency
- Simplifies the dependency tree and reduces potential conflicts