### PR TITLE
build(npm): remove unused ESLint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
-    "eslint-module-utils": "^2.8.0",
     "eslint-plugin-es-x": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       eslint-config-standard-with-typescript:
         specifier: ^36.1.0
         version: 36.1.1(@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)(typescript@5.6.3)
-      eslint-module-utils:
-        specifier: ^2.8.0
-        version: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       eslint-plugin-es-x:
         specifier: ^8.0.0
         version: 8.0.0(eslint@8.57.1)


### PR DESCRIPTION
- removed `eslint-module-utils` from `package.json`
- updated `pnpm-lock.yaml` to reflect the removal of the dependency
- this change helps to streamline the project by eliminating unnecessary packages