### PR TITLE
build(npm): add `typedoc-github-wiki-theme` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier-plugin-packagejson": "^2.4.5",
     "ts-node": "^10.9.1",
     "typedoc": "^0.26.3",
+    "typedoc-github-wiki-theme": "^2.0.0",
     "typescript": "^5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       typedoc:
         specifier: ^0.26.3
         version: 0.26.10(typescript@5.6.3)
+      typedoc-github-wiki-theme:
+        specifier: ^2.0.0
+        version: 2.0.0(typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)))
       typescript:
         specifier: ^5.1.6
         version: 5.6.3
@@ -1285,6 +1288,17 @@ packages:
   typed-array-length@1.0.6:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
+
+  typedoc-github-wiki-theme@2.0.0:
+    resolution: {integrity: sha512-LwWS+14xNerup0BLR9sowSw0T0bTwNg5CCU90kvsCMWDocEFpDuuiD/5LPSvS1xns1KPY2QbfejuVj+nOvop2Q==}
+    peerDependencies:
+      typedoc-plugin-markdown: '>=4.0.0'
+
+  typedoc-plugin-markdown@4.2.9:
+    resolution: {integrity: sha512-Wqmx+7ezKFgtTklEq/iUhQ5uFeBDhAT6wiS2na9cFLidIpl9jpDHJy/COYh8jUZXgIRIZVQ/bPNjyrnPFoDwzg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.26.x
 
   typedoc@0.26.10:
     resolution: {integrity: sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==}
@@ -2772,6 +2786,14 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+
+  typedoc-github-wiki-theme@2.0.0(typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3))):
+    dependencies:
+      typedoc-plugin-markdown: 4.2.9(typedoc@0.26.10(typescript@5.6.3))
+
+  typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)):
+    dependencies:
+      typedoc: 0.26.10(typescript@5.6.3)
 
   typedoc@0.26.10(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
- Added `typedoc-github-wiki-theme` with version `2.0.0` to `package.json`
- Updated `pnpm-lock.yaml` to include the new dependency and its resolutions
- Ensured compatibility with `typedoc` and `typedoc-plugin-markdown`