### PR TITLE
build(npm): add `typedoc-plugin-markdown` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.26.3",
     "typedoc-github-wiki-theme": "^2.0.0",
+    "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       typedoc-github-wiki-theme:
         specifier: ^2.0.0
         version: 2.0.0(typedoc-plugin-markdown@4.2.9(typedoc@0.26.10(typescript@5.6.3)))
+      typedoc-plugin-markdown:
+        specifier: ^4.2.9
+        version: 4.2.9(typedoc@0.26.10(typescript@5.6.3))
       typescript:
         specifier: ^5.1.6
         version: 5.6.3


### PR DESCRIPTION
- Introduced `typedoc-plugin-markdown` with version `4.2.9` to enhance documentation generation.
- Updated `pnpm-lock.yaml` to reflect the new dependency and its specifications.
- Ensures better integration of TypeDoc with Markdown outputs for improved documentation clarity.