### PR TITLE
test: remove outdated test for `hello` function

### DIFF
--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,7 +1,0 @@
-import { expect, test } from "@jest/globals";
-
-import { hello } from "../index";
-
-test("test", () => {
-  expect(hello()).toBe("Hello world!");
-});


### PR DESCRIPTION
- eliminated the test case for `hello` function in `src/test/test.ts`
- this test was redundant and no longer aligned with current functionality