### PR TITLE
build(npm): update documentation script to include plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "tsc --build --clean && tsc",
-    "doc": "typedoc",
+    "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-github-wiki-theme",
     "format": "prettier --write .",
     "format:check": "prettier -c .",
     "lint": "eslint --fix . --ext .ts --ignore-path .gitignore",


### PR DESCRIPTION
- Modify the `doc` script in `package.json` to use `typedoc` with additional plugins for Markdown and GitHub wiki theme
- This change enhances documentation generation by integrating better formatting and themes for easier readability