### PR TITLE
chore(typedoc): update output directory for documentation

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts"],
-  "out": "docs"
+  "out": "wiki"
 }


### PR DESCRIPTION
- Changed the output directory from `docs` to `wiki` in `typedoc.json`
- This change aligns the documentation output with the project structure and intended use.