### PR TITLE
ci(Github Actions): add GitHub Actions workflow for document deployment

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -1,0 +1,33 @@
+name: Document
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/document.yml
+      - src/**
+      - README.md
+permissions:
+  contents: write
+jobs:
+  document:
+    name: Deploy document to Github Wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: 22
+      - name: Install dependencies
+        run: pnpm i
+      - name: Generate wiki
+        run: pnpm run doc
+      - name: Publish
+        uses: Andrew-Chen-Wang/github-wiki-action@v4


### PR DESCRIPTION
- Introduce a new workflow in `.github/workflows/document.yml`
- Automatically deploys documentation to GitHub Wiki on pushes to `master`
- Utilizes `pnpm` for dependency management and builds the documentation