### PR TITLE
ci(Github Actions): update lint workflow to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: Check lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- changed `runs-on` from `ubuntu-latest` to `ubuntu-24.04` in `.github/workflows/lint.yml`
- ensures compatibility with latest dependencies and tools in the CI environment