### PR TITLE
ci(Github Actions): update pnpm version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
- Change the `pnpm` version from `8` to `9` in `.github/workflows/lint.yml`
- This update ensures compatibility with the latest features and improvements in `pnpm` version `9`