### PR TITLE
ci(Github Actions): update runner version for document deployment

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   document:
     name: Deploy document to Github Wiki
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Change `runs-on` from `ubuntu-latest` to `ubuntu-24.04`
- Ensures compatibility with updated dependencies and features in the workflow environment