### PR TITLE
chore(dependabot): correct commit message prefix in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     commit-message:
-      prefix: ci(Github Action)
+      prefix: ci(Github Actions)
     directory: /
     open-pull-requests-limit: 1000
     schedule:


### PR DESCRIPTION
- changed the commit message prefix from `ci(Github Action)` to `ci(Github Actions)` for consistency
- ensures clarity in the purpose of the updates made by Dependabot