### PR TITLE
chore(tsconfig): add include paths for source and test directories

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
-  }
+  },
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
- Added `include` property to `tsconfig.json` to specify `src` and `test` directories.
- This change ensures TypeScript compiles files from both directories, enhancing development flexibility.