### PR TITLE
chore(eslint): remove project reference from parserOptions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,8 +6,6 @@ extends:
   - prettier
 parserOptions:
   ecmaVersion: latest
-  project:
-    - tsconfig.json
   sourceType: module
 plugins:
   - simple-import-sort


### PR DESCRIPTION
- Deleted the `project` field in the `.eslintrc.yml` to streamline ESLint configuration
- This change simplifies the setup, as the TypeScript project configuration is no longer necessary for linting