### PR TITLE
build(npm): remove `eslint-visitor-keys` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-simple-import-sort": "^12.0.0",
-    "eslint-visitor-keys": "^4.0.0",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
     "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^12.0.0
         version: 12.1.1(eslint@8.57.1)
-      eslint-visitor-keys:
-        specifier: ^4.0.0
-        version: 4.1.0
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -597,10 +594,6 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.1.0:
-    resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -2013,8 +2006,6 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@4.1.0: {}
 
   eslint@8.57.1:
     dependencies:


### PR DESCRIPTION
- Removed `eslint-visitor-keys` from `package.json` and `pnpm-lock.yaml`
- This change helps to streamline dependencies and reduce package size
- Ensures compatibility with other ESLint plugins by eliminating an unused package