### PR TITLE
build(npm): add module type to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "author": "HoshinoRei",
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "license": "MIT",
   "author": "HoshinoRei",
-  "main": "dist/index.js",
   "type": "module",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
- Added `"type": "module"` to `package.json` to specify module format
- This change allows the use of ES module syntax in the codebase, improving compatibility with modern JavaScript features