### PR TITLE
build(npm): simplify linting scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-github-wiki-theme",
     "format": "prettier --write .",
     "format:check": "prettier -c .",
-    "lint": "eslint --fix .",
-    "lint:check": "eslint ."
+    "lint": "eslint --fix . --ext .ts",
+    "lint:check": "eslint . --ext .ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-github-wiki-theme",
     "format": "prettier --write .",
     "format:check": "prettier -c .",
-    "lint": "eslint --fix . --ext .ts --ignore-path .gitignore",
-    "lint:check": "eslint . --ext .ts --ignore-path .gitignore"
+    "lint": "eslint --fix .",
+    "lint:check": "eslint ."
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",


### PR DESCRIPTION
- Removed `--ignore-path .gitignore` option from the lint scripts in `package.json`
- This change streamlines the linting process and ensures all files are checked by default, improving usability for developers