### PR TITLE
chore(eslint): remove `simple-import-sort` plugin configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,8 +10,3 @@ parserOptions:
   project:
     - tsconfig.json
   sourceType: module
-plugins:
-  - simple-import-sort
-rules:
-  simple-import-sort/imports: error
-  simple-import-sort/exports: error


### PR DESCRIPTION
- removed the `simple-import-sort` plugin from `.eslintrc.yml`
- eliminated associated rules for imports and exports to streamline linting configuration
- changes simplify the ESLint setup and focus on essential rules