### PR TITLE
build(npm): remove unused `eslint-plugin-promise` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-config-standard-with-typescript": "^36.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.1",
-    "eslint-plugin-promise": "^6.1.1",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
     "typedoc": "^0.26.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       eslint-plugin-n:
         specifier: ^16.0.1
         version: 16.6.2(eslint@8.57.1)
-      eslint-plugin-promise:
-        specifier: ^6.1.1
-        version: 6.6.0(eslint@8.57.1)
       prettier:
         specifier: 3.3.3
         version: 3.3.3


### PR DESCRIPTION
- Removed `eslint-plugin-promise` from `package.json` and `pnpm-lock.yaml`