### PR TITLE
build(npm): remove `eslint-plugin-n` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-n": "^16.0.1",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
     "typedoc": "^0.26.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.27.5
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
-      eslint-plugin-n:
-        specifier: ^16.0.1
-        version: 16.6.2(eslint@8.57.1)
       prettier:
         specifier: 3.3.3
         version: 3.3.3


### PR DESCRIPTION
- Deleted `eslint-plugin-n` from `package.json` and `pnpm-lock.yaml`
- No functionality is affected as the plugin was not in use