### PR TITLE
build(npm): remove `eslint-plugin-import` and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^36.1.0",
-    "eslint-plugin-import": "^2.27.5",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
     "typedoc": "^0.26.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       eslint-config-standard-with-typescript:
         specifier: ^36.1.0
         version: 36.1.1(@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)(typescript@5.6.3)
-      eslint-plugin-import:
-        specifier: ^2.27.5
-        version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -1860,10 +1857,10 @@ snapshots:
       globals: 13.24.0
       ignore: 5.2.4
       is-builtin-module: 3.2.1
-      is-core-module: 2.13.1
+      is-core-module: 2.15.1
       minimatch: 3.1.2
       resolve: 1.22.4
-      semver: 7.5.4
+      semver: 7.6.3
 
   eslint-plugin-promise@6.6.0(eslint@8.57.1):
     dependencies:


### PR DESCRIPTION
- Removed `eslint-plugin-import` from `package.json`
- Updated `is-core-module` from `2.13.1` to `2.15.1` in `pnpm-lock.yaml`
- Updated `semver` from `7.5.4` to `7.6.3` in `pnpm-lock.yaml`
- Adjusted related package versions to ensure compatibility and reduce redundancy