### PR TITLE
chore(vite): add initial Vite configuration for library build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,19 @@
+import { resolve } from "path"
+import { defineConfig } from "vite"
+import dts from "vite-plugin-dts"
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "typescriptNpmPackageTemplate",
+      formats: ["es", "umd"],
+      fileName: "index",
+    },
+  },
+  plugins: [
+    dts({
+      rollupTypes: true,
+    }),
+  ],
+})


### PR DESCRIPTION
- Create `vite.config.ts` to configure Vite for building the library
- Set up entry point at `src/index.ts` for the library
- Specify output formats as `es` and `umd` for compatibility
- Integrate `vite-plugin-dts` for TypeScript definitions generation