### PR TITLE
chore(prettier): update configuration to disable semicolons

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,3 @@
 plugins:
   - "prettier-plugin-packagejson"
+semi: false

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,10 @@
-import pluginJs from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
-import importPlugin from "eslint-plugin-import";
-import simpleImportSort from "eslint-plugin-simple-import-sort";
-import globals from "globals";
+import pluginJs from "@eslint/js"
+import eslintConfigPrettier from "eslint-config-prettier"
+import importPlugin from "eslint-plugin-import"
+import simpleImportSort from "eslint-plugin-simple-import-sort"
+import globals from "globals"
 // eslint-disable-next-line import/no-unresolved
-import tseslint from "typescript-eslint";
+import tseslint from "typescript-eslint"
 
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
@@ -22,4 +22,4 @@ export default [
       "simple-import-sort/exports": "error",
     },
   },
-];
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@
  * @returns "Hello world!"
  */
 export function hello(): string {
-  return "Hello world!";
+  return "Hello world!"
 }


### PR DESCRIPTION
- Added `semi: false` to `.prettierrc.yml` to configure Prettier to omit semicolons.
- This change aligns with the project's coding style preferences for a cleaner syntax.
- remove unnecessary semi-colons in `eslint.config.js` for cleaner code
- update `src/index.ts` to omit the semi-colon in the `hello` function return statement