### PR TITLE
build(npm): add development script for Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "tsc && vite build",
+    "dev": "vite",
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-github-wiki-theme",
     "format": "prettier --write .",
     "format:check": "prettier -c .",


### PR DESCRIPTION
- Introduced a new script named `dev` in `package.json` to streamline the development process with Vite.
- This addition allows developers to easily start a local development server for testing and iteration.