### PR TITLE
chore(tsconfig): update module target for better compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "es2022",
+    "module": "ESNext",
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
- Change `module` option from `es2022` to `ESNext`
- This adjustment improves compatibility with future ECMAScript features and aligns with current best practices in TypeScript configurations.