### PR TITLE
chore(tsconfig): update `moduleResolution` to use bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",


### PR DESCRIPTION
- Changed `moduleResolution` from `node` to `bundler` to improve compatibility with modern build tools
- This change is necessary to optimize the package for bundling scenarios, enhancing the development workflow and output quality